### PR TITLE
secure references

### DIFF
--- a/ALL.tex
+++ b/ALL.tex
@@ -333,7 +333,7 @@ Metadata record of a standard:
 - RDF https://fairsharing.org/bsg-s000559 
 
 Non-article Published Work
-- my Zenodo Deposit for polyA (http://doi.org/10.5281/zenodo.47641)
+- my Zenodo Deposit for polyA (https://doi.org/10.5281/zenodo.47641)
 - myExperiment Workflow (http://www.myexperiment.org/workflows/2999.html)
 - Jupyter notebook on GitHub (https://github.com/VidhyasreeRamu/\newline
 GlobalClimateChange/blob/master/\newline
@@ -578,7 +578,7 @@ Examples of their application across types of digital resource &
 
 
 - my Zenodo Deposit for polyA \newline 
-(http://doi.org/10.5281/zenodo.47641)\newline 
+(https://doi.org/10.5281/zenodo.47641)\newline 
 Test Query:  10.5281/zenodo.47641  orthology\newline 
 GOOGLE: Pass (\verb|#1| hit);  BING:  Fail (no hits); Yahoo: Fail (no hits); Baidu: Pass (\verb|#1| hit) 
 \newline 

--- a/Distributions/FM_F2.tex
+++ b/Distributions/FM_F2.tex
@@ -120,7 +120,7 @@ Metadata record of a standard:
 - RDF https://fairsharing.org/bsg-s000559 
 
 Non-article Published Work
-- my Zenodo Deposit for polyA (http://doi.org/10.5281/zenodo.47641)
+- my Zenodo Deposit for polyA (https://doi.org/10.5281/zenodo.47641)
 - myExperiment Workflow (http://www.myexperiment.org/workflows/2999.html)
 - Jupyter notebook on GitHub (https://github.com/VidhyasreeRamu/GlobalClimateChange/blob/master/GlobalWarmingAnalysis.ipynb)
 

--- a/Distributions/FM_F4.tex
+++ b/Distributions/FM_F4.tex
@@ -129,7 +129,7 @@ Examples of their application across types of digital resource &
 
 
 - my Zenodo Deposit for polyA \newline 
-(http://doi.org/10.5281/zenodo.47641)\newline 
+(https://doi.org/10.5281/zenodo.47641)\newline 
 Test Query:  10.5281/zenodo.47641  orthology\newline 
 GOOGLE: Pass (\verb|#1| hit);  BING:  Fail (no hits); Yahoo: Fail (no hits); Baidu: Pass (\verb|#1| hit) 
 \newline 

--- a/FM_A1.1
+++ b/FM_A1.1
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_A1.2
+++ b/FM_A1.2
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_A2
+++ b/FM_A2
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_F1A
+++ b/FM_F1A
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-20T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_F1B
+++ b/FM_F1B
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-20T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_F2
+++ b/FM_F2
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-20T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_F3
+++ b/FM_F3
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_F4
+++ b/FM_F4
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_I1
+++ b/FM_I1
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_I2
+++ b/FM_I2
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_I3
+++ b/FM_I3
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_R1.1
+++ b/FM_R1.1
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_R1.2
+++ b/FM_R1.2
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/FM_R1.3
+++ b/FM_R1.3
@@ -51,6 +51,6 @@ sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;
  dcterms:rightsHolder <http://go-fair.org> ;
- pav:authoredBy "Mark Wilkinson" , <http://orcid.org/0000-0001-6960-357X> ;
+ pav:authoredBy "Mark Wilkinson" , <https://orcid.org/0000-0001-6960-357X> ;
  pav:versionNumber "1" ;
 }

--- a/MetricsEvaluatorCode/Perl/fair_metrics_accessor
+++ b/MetricsEvaluatorCode/Perl/fair_metrics_accessor
@@ -79,7 +79,7 @@ package fair_metrics_accessor;
       'dcat:publisher' => ['http://wilkinsonlab.info'],
       'pfund:hasPrincipalInvestigator' => ["Dr. Mark Wilkinson"],
       'dc:creator' => 'http://wilkinsonlab.info',
-      'pav:authoredBy' => ['http://orcid.org/0000-0002-9699-485X'],
+      'pav:authoredBy' => ['https://orcid.org/0000-0002-9699-485X'],
       'pav:version' => '7 June, 2017',
       'dcat:contactPoint' => 'http://biordf.org/DataFairPort/MiscRDF/Wilkinson.rdf',
       'dc:license' => "https://creativecommons.org/licenses/by/4.0",

--- a/MetricsEvaluatorCode/Perl/readme
+++ b/MetricsEvaluatorCode/Perl/readme
@@ -14,7 +14,7 @@ is the endpoint for the test that the URI scheme is registered somewhere.
 
 so:
 
-echo  '{ "spec" : "http://dx.doi.org" }' | curl -H "Content-Type: application/json" -d @-  http://fairdata.systems/cgi-bin/fair_metrics/Metrics/metric_unique_identifier
+echo  '{ "spec" : "https://doi.org" }' | curl -H "Content-Type: application/json" -d @-  http://fairdata.systems/cgi-bin/fair_metrics/Metrics/metric_unique_identifier
 
 
 will execute the test of whether DOIs are valid identifier schemas (they are... we hope!)

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Initiatives
 
 Publications
 
-* [Preprint describing the metrics in this Git](http://dx.doi.org/10.1101/225490)
+* [Preprint describing the metrics in this Git](https://doi.org/10.1101/225490)


### PR DESCRIPTION
Hello :-)

both [ORCID ](https://orcid.org/blog/2017/11/16/announcing-api-21-orcid-ids-are-now-https) and DOI switched their sites & services to HTTPS ([see also](https://www.crossref.org/blog/new-crossref-doi-display-guidelines-are-on-the-way/)).

There are many other domains, whose `http` links could be changed to `https` (nature.com, w3.org, etc.). Please let me know whether such a (larger) PR would be accepted as well.

Kind regards!