### PR TITLE
add missing rdf namespace prefix

### DIFF
--- a/FM_A1.1
+++ b/FM_A1.1
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_A1.1> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_A1.1#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;
@@ -20,20 +21,20 @@ sub:Head {
        np:hasPublicationInfo sub:pubinfo ;
        a np:Nanopublication .
  }
- 
+
 sub:assertion {
  this: a fair:FAIR-Metric ;
   foaf:primaryTopic fair:A1.1 .
 
  }
- 
+
 sub:provenance {
  sub:assertion dcterms:author  "Michel Dumontier", "Mark Wilkinson" , "Susanna Sansone", "Peter Doorn", "Luiz Bonino", "Erik Schultes" ;
  rdfs:comment "FAIR Metric for Fair Principle A1.1"^^xsd:string ;
  dcat:distribution _:dist1 ;
- dcat:distribution _:dist2 ; 
+ dcat:distribution _:dist2 ;
  prov:wasGeneratedBy "FAIR Metrics Working Group" .
- 
+
  _:dist1 dcelem:format "application/x-texinfo" ;
 	rdf:type <http://rdfs.org/ns/void#Dataset> ;
 	rdf:type <http://www.w3.org/ns/dcat#Distribution> ;
@@ -46,7 +47,7 @@ sub:provenance {
 
 }
 
- 
+
 sub:pubinfo {
  this: dcterms:created "2017-11-21T00:00:00.0Z"^^xsd:dateTime ;
  dcterms:rights <https://creativecommons.org/publicdomain/zero/1.0> ;

--- a/FM_A1.2
+++ b/FM_A1.2
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_A1.2> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_A1.2#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_A2
+++ b/FM_A2
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_A2> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_A2#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_F1A
+++ b/FM_F1A
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_F1A> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_F1A#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_F1B
+++ b/FM_F1B
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_F1B> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_F1B#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_F2
+++ b/FM_F2
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_F2> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_F2#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_F3
+++ b/FM_F3
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_F3> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_F3#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_F4
+++ b/FM_F4
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_F4> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_F4#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_I1
+++ b/FM_I1
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_I1> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_I1#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_I2
+++ b/FM_I2
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_I2> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_I2#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_I3
+++ b/FM_I3
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_I3> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_I3#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_R1.1
+++ b/FM_R1.1
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_R1.1> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_R1.1#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_R1.2
+++ b/FM_R1.2
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_R1.2> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_R1.2#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;

--- a/FM_R1.3
+++ b/FM_R1.3
@@ -1,18 +1,19 @@
 @prefix this: <https://purl.org/fair-metrics/FM_R1.3> .  # canonical URI for the metric
 @prefix sub: <https://purl.org/fair-metrics/FM_R1.3#> .
- @prefix dcterms: <http://purl.org/dc/terms/> .
- @prefix dcelem: <http://purl.org/dc/elements/1.1/> .
- @prefix np: <http://www.nanopub.org/nschema#> .
- @prefix nx: <http://www.nextprot.org/db/search#> .
- @prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
- @prefix prov: <http://www.w3.org/ns/prov#> .
- @prefix prv: <http://purl.org/net/provenance/ns#> .
- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
- @prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
- @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
- @prefix fair: <http://purl.org/fair-ontology#> . 
- @prefix foaf: <http://xmlns.com/foaf/0.1/> .
- @prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcelem: <http://purl.org/dc/elements/1.1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix nx: <http://www.nextprot.org/db/search#> .
+@prefix pav: <http://swan.mindinformatics.org/ontologies/1.2/pav/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://purl.org/net/provenance/ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro: <http://purl.org/obo/owl/OBO_REL#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fair: <http://purl.org/fair-ontology#> . 
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;


### PR DESCRIPTION
when calling a given metric with rapper, I noticed that the rdf namespace was missing from the each document, so I added it. Hope that's ok!

```
rapper -i trig  https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1
rapper: Parsing URI https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1 with parser trig
rapper: Serializing with serializer ntriples
<https://purl.org/fair-metrics/FM_A1.1#nanopub> <http://www.nanopub.org/nschema#hasAssertion> <https://purl.org/fair-metrics/FM_A1.1#assertion> .
<https://purl.org/fair-metrics/FM_A1.1#nanopub> <http://www.nanopub.org/nschema#hasProvenance> <https://purl.org/fair-metrics/FM_A1.1#provenance> .
<https://purl.org/fair-metrics/FM_A1.1#nanopub> <http://www.nanopub.org/nschema#hasPublicationInfo> <https://purl.org/fair-metrics/FM_A1.1#pubinfo> .
<https://purl.org/fair-metrics/FM_A1.1#nanopub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.nanopub.org/nschema#Nanopublication> .
<https://purl.org/fair-metrics/FM_A1.1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/fair-ontology#FAIR-Metric> .
<https://purl.org/fair-metrics/FM_A1.1> <http://xmlns.com/foaf/0.1/primaryTopic> <http://purl.org/fair-ontology#A1.1> .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Michel Dumontier" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Mark Wilkinson" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Susanna Sansone" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Peter Doorn" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Luiz Bonino" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://purl.org/dc/terms/author> "Erik Schultes" .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://www.w3.org/2000/01/rdf-schema#comment> "FAIR Metric for Fair Principle A1.1"^^<http://www.w3.org/2001/XMLSchema#string> .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://www.w3.org/ns/dcat#distribution> _:dist1 .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://www.w3.org/ns/dcat#distribution> _:dist2 .
<https://purl.org/fair-metrics/FM_A1.1#assertion> <http://www.w3.org/ns/prov#wasGeneratedBy> "FAIR Metrics Working Group" .
rapper: Error -  - The namespace prefix in "rdf:type" was not declared.
rapper: Error - URI https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1:38 - Failed to convert qname rdf:type to URI
_:dist1 <http://purl.org/dc/elements/1.1/format> "application/x-texinfo" .
rapper: Error - URI https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1:38 - syntax error, unexpected $end, expecting }
rapper: Failed to parse URI https://raw.githubusercontent.com/FAIRMetrics/Metrics/master/FM_A1.1 trig content
rapper: Parsing returned 17 triples
```