### PR TITLE
Additional information on machine readable metrics

### DIFF
--- a/FM_A1.1
+++ b/FM_A1.1
@@ -15,6 +15,8 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
+@prefix fm: <https://purl.org/fair-metrics/terms/> .
+
 sub:Head {
   sub:nanopub np:hasAssertion sub:assertion ;
        np:hasProvenance sub:provenance ;
@@ -30,10 +32,22 @@ sub:assertion {
 
 sub:provenance {
  sub:assertion dcterms:author  "Michel Dumontier", "Mark Wilkinson" , "Susanna Sansone", "Peter Doorn", "Luiz Bonino", "Erik Schultes" ;
+ dcterms:title "Access Protocol"^^xsd:string ;
  rdfs:comment "FAIR Metric for Fair Principle A1.1"^^xsd:string ;
+
+ fm:measuring "The nature and use limitations of the access protocol"^^xsd:string ;
+ fm:reason "Access to a resource may be limited by the specified communication protocol. In particular, we are worried about access to technical specifications and any costs associated with implementing the protocol. Protocols that are closed source or that have royalties associated with them could prevent users from being able to obtain the resource"^^xsd:string ;
+ fm:requirements "i) A URL to the description of the protocol\nii) true/false as to whether the protocol is open source\niii) true/false as to whether the protocol is (royalty) free\newline"^^xsd:string ;
+ fm:procedure "Do an HTTP get on the URL to see if it returns a valid document. Ideally, we would have a universal database of communication protocols from which we can check this URL. We also check whether questions 2 and 3 are true or false."^^xsd:string ;
+ fm:validation "The HTTP GET on the URL should return a 200,202,203 or 206 HTTP response after resolving all and any prior redirects. e.g. 301 -> 302 -> 200 OK. The other two should be true/false."^^xsd:string ;
+ fm:relevance "All"^^xsd:string ;
+ fm:examples "None"^^xsd:string ;
+ fm:comments "None"^^xsd:string ;
+
  dcat:distribution _:dist1 ;
  dcat:distribution _:dist2 ;
  prov:wasGeneratedBy "FAIR Metrics Working Group" .
+
 
  _:dist1 dcelem:format "application/x-texinfo" ;
 	rdf:type <http://rdfs.org/ns/void#Dataset> ;

--- a/FM_A1.1
+++ b/FM_A1.1
@@ -37,7 +37,7 @@ sub:provenance {
 
  fm:measuring "The nature and use limitations of the access protocol"^^xsd:string ;
  fm:reason "Access to a resource may be limited by the specified communication protocol. In particular, we are worried about access to technical specifications and any costs associated with implementing the protocol. Protocols that are closed source or that have royalties associated with them could prevent users from being able to obtain the resource"^^xsd:string ;
- fm:requirements "i) A URL to the description of the protocol\nii) true/false as to whether the protocol is open source\niii) true/false as to whether the protocol is (royalty) free\newline"^^xsd:string ;
+ fm:requirements "i) A URL to the description of the protocol\nii) true/false as to whether the protocol is open source\niii) true/false as to whether the protocol is (royalty) free"^^xsd:string ;
  fm:procedure "Do an HTTP get on the URL to see if it returns a valid document. Ideally, we would have a universal database of communication protocols from which we can check this URL. We also check whether questions 2 and 3 are true or false."^^xsd:string ;
  fm:validation "The HTTP GET on the URL should return a 200,202,203 or 206 HTTP response after resolving all and any prior redirects. e.g. 301 -> 302 -> 200 OK. The other two should be true/false."^^xsd:string ;
  fm:relevance "All"^^xsd:string ;

--- a/script.py
+++ b/script.py
@@ -1,0 +1,116 @@
+from rdflib import ConjunctiveGraph, URIRef
+from rdflib.namespace import DCTERMS, RDFS, FOAF
+from rdflib.namespace import Namespace
+
+fairGraph = ConjunctiveGraph()
+# fairGraph.parse('http://purl.org/fair-ontology#', format='trig')
+
+g = ConjunctiveGraph()
+g.parse('FM_A1.1', format='trig')
+#for ctx in g.contexts():
+#    print ctx.identifier, '----------'
+#    for s,p,o in ctx:
+#        print s,p,o
+#    print '=================================='
+
+FM = Namespace('https://purl.org/fair-metrics/terms/')
+
+
+class FairMetricData():
+    def __init__(self, id):
+        self.base = 'https://purl.org/fair-metrics/'
+        self.id = URIRef(id)
+        print "TODO: really should parse g from ID"
+        self.g = g
+        self.assertion = URIRef(id+'#assertion')
+
+    def getID(self):
+        return self.id
+
+    def getShortID(self):
+        return self.id.replace(self.base, '')
+
+    def getAuthors(self):
+        return [o for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.author)]
+
+    def getTitle(self):
+        return [o for o in self.g.objects(subject=self.assertion, predicate=RDFS.comment)]
+
+    def getShortTitle(self):
+        return [o for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.title)]
+
+    def getTopicDescription(self):
+        descs = []
+        for o in self.g.objects(subject=self.id, predicate=FOAF.primaryTopic):
+            # o should be fair:A1.1
+            for o2 in fairGraph.objects(subject=o, predicate=DCTERMS.description):
+                descs.append(o2)
+        return descs
+
+    def getTopicTitle(self):
+        descs = []
+        for o in self.g.objects(subject=self.id, predicate=FOAF.primaryTopic):
+            # o should be fair:A1.1
+            for o2 in fairGraph.objects(subject=o, predicate=DCTERMS.title):
+                descs.append(o2)
+        return descs
+
+    def getMeasuring(self):
+        # return fm:measuring
+        pred = FM.measuring
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getReason(self):
+        # return fm:reason
+        pred = FM.reason
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getRequirements(self):
+        # return fm:requirements
+        pred = FM.requirements
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getProcedure(self):
+        # return fm:procedure
+        pred = FM.procedure
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getValidation(self):
+        # return fm:validation
+        pred = FM.validation
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getRelevance(self):
+        # return fm:relevance
+        pred = FM.relevance
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getExamples(self):
+        # return fm:examples
+        pred = FM.examples
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+    def getComments(self):
+        # return fm:comments
+        pred = FM.comments
+        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+
+
+# The idea is that we could fill the table http://fairmetrics.org/fairmetricform.html
+# from a given metric IRI
+id = 'https://purl.org/fair-metrics/FM_A1.1'
+fm = FairMetricData(id)
+print fm.getShortID() + " - " + fm.getID()
+print fm.getAuthors()
+print fm.getTitle()
+print fm.getShortTitle()
+print fm.getTopicTitle()
+print fm.getTopicDescription()
+print fm.getMeasuring()
+print fm.getReason()
+print fm.getRequirements()
+print fm.getProcedure()
+print fm.getValidation()
+print fm.getRelevance()
+print fm.getExamples()
+print fm.getComments()

--- a/script.py
+++ b/script.py
@@ -1,28 +1,32 @@
+import os
+import sys
+import jinja2
+
 from rdflib import ConjunctiveGraph, URIRef
 from rdflib.namespace import DCTERMS, RDFS, FOAF
 from rdflib.namespace import Namespace
 
-fairGraph = ConjunctiveGraph()
-# fairGraph.parse('http://purl.org/fair-ontology#', format='trig')
-
-g = ConjunctiveGraph()
-g.parse('FM_A1.1', format='trig')
-#for ctx in g.contexts():
-#    print ctx.identifier, '----------'
-#    for s,p,o in ctx:
-#        print s,p,o
-#    print '=================================='
+args = sys.argv
+if len(args)!=2:
+    raise Exception('Expected metric IRI as input')
 
 FM = Namespace('https://purl.org/fair-metrics/terms/')
 
+fairGraph = ConjunctiveGraph()
+fairGraph.parse('http://purl.org/fair-ontology#', format='trig')
+
+fairTermGraph = ConjunctiveGraph()
+fairTermGraph.parse('terms', format='n3')
 
 class FairMetricData():
     def __init__(self, id):
         self.base = 'https://purl.org/fair-metrics/'
         self.id = URIRef(id)
-        print "TODO: really should parse g from ID"
-        self.g = g
         self.assertion = URIRef(id+'#assertion')
+
+        id = id.replace(self.base, '')  # HACK -- remove this line before merging commit
+        self.g = ConjunctiveGraph()
+        self.g.parse(id, format='trig')
 
     def getID(self):
         return self.id
@@ -31,86 +35,136 @@ class FairMetricData():
         return self.id.replace(self.base, '')
 
     def getAuthors(self):
-        return [o for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.author)]
+        authors = [o.toPython() for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.author)]
+        authors.sort()
+        return ' \\\\ '.join(authors)
 
     def getTitle(self):
-        return [o for o in self.g.objects(subject=self.assertion, predicate=RDFS.comment)]
+        return ', '.join([o.toPython() for o in self.g.objects(subject=self.assertion, predicate=RDFS.comment)])
 
     def getShortTitle(self):
-        return [o for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.title)]
+        return ', '.join([o.toPython() for o in self.g.objects(subject=self.assertion, predicate=DCTERMS.title)])
 
     def getTopicDescription(self):
         descs = []
         for o in self.g.objects(subject=self.id, predicate=FOAF.primaryTopic):
             # o should be fair:A1.1
             for o2 in fairGraph.objects(subject=o, predicate=DCTERMS.description):
-                descs.append(o2)
-        return descs
+                descs.append(o2.toPython())
+        return ' '.join(descs)
 
     def getTopicTitle(self):
         descs = []
         for o in self.g.objects(subject=self.id, predicate=FOAF.primaryTopic):
             # o should be fair:A1.1
             for o2 in fairGraph.objects(subject=o, predicate=DCTERMS.title):
-                descs.append(o2)
-        return descs
+                descs.append(o2.toPython())
+        return ' '.join(descs)
 
     def getMeasuring(self):
         # return fm:measuring
-        pred = FM.measuring
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.measuring)
 
     def getReason(self):
         # return fm:reason
-        pred = FM.reason
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.reason)
 
     def getRequirements(self):
         # return fm:requirements
-        pred = FM.requirements
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.requirements)
 
     def getProcedure(self):
         # return fm:procedure
-        pred = FM.procedure
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.procedure)
 
     def getValidation(self):
         # return fm:validation
-        pred = FM.validation
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.validation)
 
     def getRelevance(self):
         # return fm:relevance
-        pred = FM.relevance
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.relevance)
 
     def getExamples(self):
         # return fm:examples
-        pred = FM.examples
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.examples)
 
     def getComments(self):
         # return fm:comments
-        pred = FM.comments
-        return [o for o in self.g.objects(subject=self.assertion, predicate=pred)]
+        return self.getFMPropertyValue(FM.comments)
+
+    def getFMPropertyLabel(self, property):
+        return ', '.join([ o.toPython() for o in fairTermGraph.objects(subject=FM[property], predicate=RDFS['label'])])
+
+    def getFMPropertyValue(self, property):
+        return ', '.join([o.toPython() for o in self.g.objects(subject=self.assertion, predicate=property)])
 
 
 # The idea is that we could fill the table http://fairmetrics.org/fairmetricform.html
 # from a given metric IRI
-id = 'https://purl.org/fair-metrics/FM_A1.1'
+# id = 'https://purl.org/fair-metrics/FM_A1.1'
+metricFile = args[1]
+id = 'https://purl.org/fair-metrics/' + metricFile
+
 fm = FairMetricData(id)
-print fm.getShortID() + " - " + fm.getID()
-print fm.getAuthors()
-print fm.getTitle()
-print fm.getShortTitle()
-print fm.getTopicTitle()
-print fm.getTopicDescription()
-print fm.getMeasuring()
-print fm.getReason()
-print fm.getRequirements()
-print fm.getProcedure()
-print fm.getValidation()
-print fm.getRelevance()
-print fm.getExamples()
-print fm.getComments()
+
+latex_jinja_env = jinja2.Environment(
+	variable_start_string = '\VAR{',
+	variable_end_string = '}',
+	trim_blocks = True,
+	autoescape = False,
+	loader = jinja2.FileSystemLoader(os.path.abspath('.'))
+)
+template = latex_jinja_env.get_template('template.tex')
+
+
+title=fm.getTitle()
+authors=fm.getAuthors()
+metricId=fm.getShortID().replace('_','-')   # Avoid _ in latex template
+metricIdVerb=fm.getID()
+shortTitle=fm.getShortTitle()
+topicTitle=fm.getTopicTitle()
+topicDesription=fm.getTopicDescription()
+measuring=fm.getMeasuring()
+reason=fm.getReason()
+requirements=fm.getRequirements().replace('\n','\\newline\n')
+procedure=fm.getProcedure()
+validation=fm.getValidation()
+relevance=fm.getRelevance()
+examples=fm.getExamples()
+comments=fm.getComments()
+measuringLabel=fm.getFMPropertyLabel('measuring')
+reasonLabel=fm.getFMPropertyLabel('reason')
+requirementsLabel=fm.getFMPropertyLabel('requirements')
+procedureLabel=fm.getFMPropertyLabel('procedure')
+validationLabel=fm.getFMPropertyLabel('validation')
+relevanceLabel=fm.getFMPropertyLabel('relevance')
+examplesLabel=fm.getFMPropertyLabel('examples')
+commentsLabel=fm.getFMPropertyLabel('comments')
+
+
+print(template.render(
+    title=title,
+    authors=authors,
+    metricId=metricId,
+    metricIdVerb=metricIdVerb,
+    shortTitle=shortTitle,
+    topicTitle=topicTitle,
+    topicDesription=topicDesription,
+    measuring=measuring,
+    reason=reason,
+    requirements=requirements,
+    procedure=procedure,
+    validation=validation,
+    relevance=relevance,
+    examples=examples,
+    comments=comments,
+    measuringLabel=measuringLabel,
+    reasonLabel=reasonLabel,
+    requirementsLabel=requirementsLabel,
+    procedureLabel=procedureLabel,
+    validationLabel=validationLabel,
+    relevanceLabel=relevanceLabel,
+    examplesLabel=examplesLabel,
+    commentsLabel=commentsLabel,
+))

--- a/template.tex
+++ b/template.tex
@@ -1,0 +1,121 @@
+\documentclass[english]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{babel}
+\usepackage{color}
+%\usepackage{amsmath}
+\usepackage{graphicx}
+\usepackage{fancyhdr}
+\usepackage{longtable}
+%\usepackage{makecell}  % $ sudo tlmgr install makecell
+%\pagestyle{fancy}
+%\fancyhf{}
+\renewcommand{\headrulewidth}{0pt}
+\setlength{\headheight}{20pt}
+
+\begin{document}
+
+% \title{FAIR Metric FM-A1.1}
+\title{ PYTHON getTitle}
+
+% \author{Mark D. Wilkinson, Susanna-Assunta Sansone, \\Erik Schultes, Peter Doorn,\\ Luiz Olavo Bonino da Silva Santos, Michel Dumontier}
+\author{ PYTHON getAuthors }
+
+\maketitle
+
+\newpage
+
+\begin{longtable}{|p{5cm}|p{9cm}|}
+
+\hline
+\emph{FIELD} & \emph{DESCRIPTION} \\
+
+\hline
+Metric Identifier &
+% FM-A1.1: \verb"https://purl.org/fair-metrics/FM_A1.1"
+[PYTHON getShortID]: \verb"[PYTHON getID]"
+\\
+
+\hline
+Metric Name &
+Access Protocol
+PYTHON getShortTitle
+
+\\
+
+\hline
+To which principle does it apply? &
+
+% A1.1 - the protocol is open, free, and universally implementable
+PYTHON getTopicTitle + getTopicDescription
+
+\\
+
+\hline
+What is being measured? &
+
+% The nature and use limitations of the access protocol.
+PYTHON getMeasuring
+
+
+\\
+
+\hline
+Why should we measure it? &
+
+% Access to a resource may be limited by the specified communication protocol. In particular, we are worried about access to technical specifications and any costs associated with implementing the protocol. Protocols that are closed source or that have royalties associated with them could prevent users from being able to obtain the resource.
+PYTHON getReason
+
+\\
+
+\hline
+What must be provided? &
+
+% i) A URL to the description of the protocol\newline
+% ii) true/false as to whether the protocol is open source\newline
+% iii) true/false as to whether the protocol is (royalty) free\newline
+PYTHON getRequirements
+
+\\
+
+\hline
+How do we measure it? &
+
+% Do an HTTP get on the URL to see if it returns a valid document. Ideally, we would have a universal database of communication protocols from which we can check this URL. We also check whether questions 2 and 3 are true or false.
+PYTHON getProcedure
+
+\\
+
+\hline
+What is a valid result? &
+
+% The HTTP GET on the URL should return a 200,202,203 or 206 HTTP response after resolving all and any prior redirects. e.g. 301 -> 302 -> 200 OK. The other two should be true/false.
+PYTHON getValidation
+
+\\
+
+\hline
+For which digital resource(s) is this relevant? &
+% All
+PYTHON getRelevance
+
+\\
+
+\hline
+Examples of their application across types of digital resource &
+% None
+PYTHON getExamples
+
+\\
+
+\hline
+
+Comments &
+% None
+PYTHON getComments
+
+\\
+\hline
+
+\end{longtable}
+\end{document}

--- a/template.tex
+++ b/template.tex
@@ -15,11 +15,9 @@
 
 \begin{document}
 
-% \title{FAIR Metric FM-A1.1}
-\title{ PYTHON getTitle}
+\title{ \VAR{ title } }
 
-% \author{Mark D. Wilkinson, Susanna-Assunta Sansone, \\Erik Schultes, Peter Doorn,\\ Luiz Olavo Bonino da Silva Santos, Michel Dumontier}
-\author{ PYTHON getAuthors }
+\author{ \VAR{ authors}  }
 
 \maketitle
 
@@ -32,90 +30,59 @@
 
 \hline
 Metric Identifier &
-% FM-A1.1: \verb"https://purl.org/fair-metrics/FM_A1.1"
-[PYTHON getShortID]: \verb"[PYTHON getID]"
+\VAR{ metricId }: \verb"\VAR{ metricIdVerb }"
 \\
 
 \hline
 Metric Name &
-Access Protocol
-PYTHON getShortTitle
-
+\VAR{ shortTitle }
 \\
 
 \hline
 To which principle does it apply? &
-
-% A1.1 - the protocol is open, free, and universally implementable
-PYTHON getTopicTitle + getTopicDescription
-
+\VAR{ topicTitle } - \VAR{ topicDesription }
 \\
 
 \hline
-What is being measured? &
-
-% The nature and use limitations of the access protocol.
-PYTHON getMeasuring
-
-
+\VAR{ measuringLabel } &
+\VAR{ measuring }
 \\
 
 \hline
-Why should we measure it? &
-
-% Access to a resource may be limited by the specified communication protocol. In particular, we are worried about access to technical specifications and any costs associated with implementing the protocol. Protocols that are closed source or that have royalties associated with them could prevent users from being able to obtain the resource.
-PYTHON getReason
-
+\VAR{ reasonLabel } &
+\VAR{ reason }
 \\
 
 \hline
-What must be provided? &
-
-% i) A URL to the description of the protocol\newline
-% ii) true/false as to whether the protocol is open source\newline
-% iii) true/false as to whether the protocol is (royalty) free\newline
-PYTHON getRequirements
-
+\VAR{ requirementsLabel } &
+\VAR{ requirements }
 \\
 
 \hline
-How do we measure it? &
-
-% Do an HTTP get on the URL to see if it returns a valid document. Ideally, we would have a universal database of communication protocols from which we can check this URL. We also check whether questions 2 and 3 are true or false.
-PYTHON getProcedure
-
+\VAR{ procedureLabel } &
+\VAR{ procedure }
 \\
 
 \hline
-What is a valid result? &
-
-% The HTTP GET on the URL should return a 200,202,203 or 206 HTTP response after resolving all and any prior redirects. e.g. 301 -> 302 -> 200 OK. The other two should be true/false.
-PYTHON getValidation
-
+\VAR{ validationLabel } &
+\VAR{ validation }
 \\
 
 \hline
-For which digital resource(s) is this relevant? &
-% All
-PYTHON getRelevance
-
+\VAR{ relevanceLabel } &
+\VAR{ relevance }
 \\
 
 \hline
-Examples of their application across types of digital resource &
-% None
-PYTHON getExamples
-
+\VAR{ examplesLabel } &
+\VAR{ examples }
 \\
 
 \hline
-
-Comments &
-% None
-PYTHON getComments
-
+\VAR{ commentsLabel } &
+\VAR{ comments }
 \\
-\hline
 
+\hline
 \end{longtable}
 \end{document}

--- a/terms
+++ b/terms
@@ -1,0 +1,72 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fm: <https://purl.org/fair-metrics/terms/> .
+
+<https://purl.org/fair-metrics/terms/>
+    dcterms:modified "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:title "FAIRMetrics Terms"@en .
+
+fm:measuring
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of what is being measured by the metric."@en ;
+    rdfs:label "What is being measured?"@en .
+
+fm:reason
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of why this is being measured."@en ;
+    rdfs:label "Why should we measure it?"@en .
+
+fm:requirements
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of what requirements need to be met for the measure to be considered successful."@en ;
+    rdfs:label "What must be provided?"@en .
+
+fm:procedure
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of how the requirements are to be measured."@en ;
+    rdfs:label "How do we measure it?"@en .
+
+fm:validation
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of what constitutes a valid result."@en ;
+    rdfs:label "What is a valid result?"@en .
+
+fm:relevance
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of digital resources for which this measure is relevant."@en ;
+    rdfs:label "For which digital resource(s) is this relevant?"@en .
+
+fm:examples
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "A description of applications across different types of digital resources."@en ;
+    rdfs:label "Examples of their application across types of digital resource"@en .
+
+fm:comments
+    a rdf:Property ;
+    dcterms:issued "2018-04-04"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    rdfs:isDefinedBy <https://purl.org/fair-metrics/terms/> ;
+    rdfs:range rdfs:Literal ;
+    rdfs:comment "Additional comments on the described metric."@en ;
+    rdfs:label "Comments"@en .


### PR DESCRIPTION
Would it make sense for the machine readable version of the metrics to contain all the information to generate the PDF's?

This PR defines a few RDF properties in the namespace `https://purl.org/fair-metrics/terms/` and adds them to the metrics (I've only added it to `FMA1.1` as a proof of concept.

This makes it possible, for a script to read all the information on the metric and present it in the desired format -- as an example, `script.py` in this PR reads `FMA1.1` and generates a latex version of the metric.

If this is something useful, I could add these properties to the other metrics in this repo.