### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/MetricsEvaluatorCode/Ruby/fairmetrics/app/controllers/concerns/shared_functions.rb
+++ b/MetricsEvaluatorCode/Ruby/fairmetrics/app/controllers/concerns/shared_functions.rb
@@ -54,7 +54,7 @@ require 'openssl'
 
     # is it a DOI?
     if (uri_str.match(/^(10.\d{4,9}\/[-\._;()\/:A-Z0-9]+$)/i))
-      uri_str = "http://dx.doi.org/#{uri_str}"  # convert to resolvable DOI URL
+      uri_str = "https://doi.org/#{uri_str}"  # convert to resolvable DOI URL
     end
 
 

--- a/MetricsEvaluatorCode/Ruby/fairmetrics/app/controllers/evaluations_controller.rb
+++ b/MetricsEvaluatorCode/Ruby/fairmetrics/app/controllers/evaluations_controller.rb
@@ -301,7 +301,7 @@ class EvaluationsController < ApiController
     #end
     #
     #resource = @evaluation.resource
-    #if (resource =~ /doi:/ or resource =~ /dx\.doi\.org/)
+    #if (resource =~ /doi:/ or resource =~ /(dx\.)?doi\.org/)
     #  canonicalizedDOI = resource.match(/(10.\d{4,9}\/[-\._;()\/:A-Z0-9]+$)/i)[1]
     #  @evaluation.resource = canonicalizedDOI
     #end

--- a/MetricsEvaluatorCode/Ruby/fairmetrics/app/views/metrics/_metric.json.jbuilder
+++ b/MetricsEvaluatorCode/Ruby/fairmetrics/app/views/metrics/_metric.json.jbuilder
@@ -1,4 +1,4 @@
-doi_url = "https://dx.doi.org/"
+doi_url = "https://doi.org/"
 fairont = "https://purl.org/fair-ontology/"
 metrics_url = "https://purl.org/fair-metrics/"
 type1= "http://purl.org/dc/dcmitype/Dataset"

--- a/MetricsEvaluatorCode/Ruby/metrictests/fair_metrics_utilities.rb
+++ b/MetricsEvaluatorCode/Ruby/metrictests/fair_metrics_utilities.rb
@@ -141,8 +141,8 @@ class Utils
       meta.guidtype = "doi"
       meta.comments << "Found a Crossref DOI.  "
 
-      Utils::resolve_uri("http://dx.doi.org/#{guid}", meta, false)  # specifically metadata
-      Utils::resolve_uri("http://dx.doi.org/#{guid}", meta, false, {"Accept" => "*/*"}) # whatever is default
+      Utils::resolve_uri("https://doi.org/#{guid}", meta, false)  # specifically metadata
+      Utils::resolve_uri("https://doi.org/#{guid}", meta, false, {"Accept" => "*/*"}) # whatever is default
       
       return meta      
     end
@@ -479,7 +479,7 @@ class Utils
 
     # is it a DOI?
     if (uri_str.match(/^(10.\d{4,9}\/[-\._;()\/:A-Z0-9]+$)/i))
-      uri_str = "http://dx.doi.org/#{uri_str}"  # convert to resolvable DOI URL
+      uri_str = "https://doi.org/#{uri_str}"  # convert to resolvable DOI URL
     end
 
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update any code that generates new DOI links. I realise that the reg-ex is commented-out, but adapted it for completeness sake anyway.

Cheers!